### PR TITLE
refactor(skills): fold Sui SDK4 gRPC guide into sentio-processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ sentio-ai-kit/
 │   │       ├── advanced-patterns.md
 │   │       ├── defi-patterns.md
 │   │       ├── store-and-points.md
-│   │       └── production-examples.md
-│   ├── sentio-platform/
-│   │   └── SKILL.md
-│   └── sui-grpc-data-format/
+│   │       ├── production-examples.md
+│   │       └── sui-sdk4-migration.md
+│   └── sentio-platform/
 │       └── SKILL.md
 └── README.md
 ```

--- a/skills/sentio-processor/SKILL.md
+++ b/skills/sentio-processor/SKILL.md
@@ -32,6 +32,7 @@ This skill follows a layered approach:
 4. **[references/store-and-points.md](references/store-and-points.md)** — Store schema advanced features (relationships, timeseries, indexes, iterators, filter operators)
 5. **[references/position-tracking-templates.md](references/position-tracking-templates.md)** — 10 protocol-specific points/position tracking templates (Simple Holding, Aave, Morpho, Vault/LP, Uni V3, Pendle, Compound, NFT, Uni V2, Uni V4)
 6. **[references/production-examples.md](references/production-examples.md)** — 7 complete production processor examples (Uniswap, AAVE, Cetus, LiquidSwap, Lombard points, Scallop)
+7. **[references/sui-sdk4-migration.md](references/sui-sdk4-migration.md)** — Migrating a Sui processor to SDK 4: gRPC vs JSON-RPC raw data shapes (transaction/object/event, protobuf oneof, Move type-string comma spacing + address form), with Sui source citations
 
 ## Project Lifecycle
 

--- a/skills/sentio-processor/references/sui-sdk4-migration.md
+++ b/skills/sentio-processor/references/sui-sdk4-migration.md
@@ -1,15 +1,12 @@
----
-name: sui-grpc-data-format
-description: Use when writing or upgrading a Sentio Sui processor on SDK 4 that touches RAW transaction / object / event structures — e.g. reading fields off `ctx.transaction`, walking programmable-transaction commands, decoding an object from `ctx.client.getObject`, or parsing Move type strings. On SDK 4 Sui chain data is fetched over gRPC, so these raw shapes follow the Sui gRPC protobuf schema and differ from the JSON-RPC shapes used by earlier SDK versions (field names, nesting, protobuf oneof unions, and type-string formatting). Not needed for typed handlers that only use `event.data_decoded`.
----
+# Migrating a Sui processor to SDK 4: gRPC vs JSON-RPC data shapes
 
-# Sui gRPC vs JSON-RPC raw data shapes (SDK 4)
+Use this when **upgrading a Sui processor to Sentio SDK 4**, or writing one that touches **raw** transaction / object / event structures (reading fields off `ctx.transaction`, walking programmable-transaction commands, decoding an object from `ctx.client.getObject`, or parsing Move type strings).
 
 ## Overview
 
-On **Sentio SDK 4**, Sui processors fetch on-chain data over **gRPC**. The decoded values from typed handlers are unchanged — the SDK normalizes them. But any code that reaches into **raw** transaction, event, or object structures now sees the **gRPC protobuf shapes**, which differ from the older JSON-RPC shapes in field names, nesting, `oneof` unions, and string formatting.
+On **SDK 4**, Sui processors fetch on-chain data over **gRPC**. The decoded values from typed handlers are unchanged — the SDK normalizes them. But any code that reaches into **raw** transaction, event, or object structures now sees the **gRPC protobuf shapes**, which differ from the older JSON-RPC shapes in field names, nesting, `oneof` unions, and string formatting.
 
-If you are upgrading a processor from an earlier SDK and it parses raw transactions / objects / Move type strings, those are the spots that need changes. A processor that only uses typed decoded values usually needs no code change (just regenerate bindings).
+If your processor parses raw transactions / objects / Move type strings, those are the spots that need changes. A processor that only uses typed decoded values usually needs no code change (just regenerate bindings).
 
 ## Authoritative schema — read the proto
 


### PR DESCRIPTION
## Summary

The Sui SDK 4 gRPC data-shape guide (added in #11 as a standalone `sui-grpc-data-format` skill) is really a **Sui → SDK 4 migration guide**, which belongs with the processor skill rather than as a separate top-level skill. This PR folds it into **`sentio-processor`** as a reference.

## Changes

- **Move** `skills/sui-grpc-data-format/SKILL.md` → `skills/sentio-processor/references/sui-sdk4-migration.md` (content unchanged).
- **Add** it as item 7 in the `sentio-processor` SKILL.md Progressive Disclosure list.
- **Remove** the standalone `sui-grpc-data-format` skill directory.
- **Update** the README plugin-structure tree.

## Content (unchanged)

gRPC vs JSON-RPC raw data shapes for SDK 4 Sui processors: transaction / object / event structures, the protobuf `oneof` pattern, and Move type-string differences (comma spacing + address form) — all with Sui source citations (`crates/sui-rpc-api/.../render.rs`, `crates/sui-types/src/sui_serde.rs`, move-core-types `language_storage.rs`). Schema source: the Sui RPC v2 protobufs (sentioxyz/sui-apis, fork of MystenLabs/sui-apis).