### PR TITLE
docs(skill): make sentio-processor v4-ready

### DIFF
--- a/skills/sentio-processor/SKILL.md
+++ b/skills/sentio-processor/SKILL.md
@@ -32,7 +32,7 @@ This skill follows a layered approach:
 4. **[references/store-and-points.md](references/store-and-points.md)** — Store schema advanced features (relationships, timeseries, indexes, iterators, filter operators)
 5. **[references/position-tracking-templates.md](references/position-tracking-templates.md)** — 10 protocol-specific points/position tracking templates (Simple Holding, Aave, Morpho, Vault/LP, Uni V3, Pendle, Compound, NFT, Uni V2, Uni V4)
 6. **[references/production-examples.md](references/production-examples.md)** — 7 complete production processor examples (Uniswap, AAVE, Cetus, LiquidSwap, Lombard points, Scallop)
-7. **[references/sui-sdk4-migration.md](references/sui-sdk4-migration.md)** — Migrating a Sui processor to SDK 4: gRPC vs JSON-RPC raw data shapes (transaction/object/event, protobuf oneof, Move type-string comma spacing + address form), with Sui source citations
+7. **[references/sui-sdk4-migration.md](references/sui-sdk4-migration.md)** — Upgrading to SDK 4: cross-chain breaking changes (dep bumps, Solana `@anchor-lang/core`, proto/RPC stack, dropped v3 back-compat) plus the Sui gRPC deep dive — raw data shapes (transaction/object/event, protobuf oneof, Move type-string comma spacing + address form), with Sui source citations
 
 ## Project Lifecycle
 
@@ -98,10 +98,10 @@ Recommend **yarn** over npm. With npm you may hit `BaseContract` / `DeferredTopi
     "test": "sentio test"
   },
   "dependencies": {
-    "@sentio/sdk": "^3.4.0"
+    "@sentio/sdk": "^4.0.0"
   },
   "devDependencies": {
-    "@sentio/cli": "^3.4.0",
+    "@sentio/cli": "^4.0.0",
     "typescript": "^5.4.5"
   }
 }
@@ -256,10 +256,15 @@ SuiObjectTypeProcessor.bind({ objectType: pool.Pool.type() })
 
 ### Solana
 
+On SDK 4, Solana uses `@anchor-lang/core` + `@solana/kit`. Import `BorshInstructionCoder` (and `Idl`/`Instruction`) from `@sentio/sdk/solana`, not from `@coral-xyz/anchor`:
+
 ```typescript
+import { SolanaGlobalProcessor } from '@sentio/sdk/solana'
+import { BorshInstructionCoder, type Idl } from '@sentio/sdk/solana'
+
 SolanaGlobalProcessor.bind({
   name: 'my-program',
-  instructionCoder: new Anchor.BorshInstructionCoder(idl),
+  instructionCoder: new BorshInstructionCoder(idl as Idl),
 }).onInstruction('transfer', async (instruction, ctx, accounts) => {
   ctx.meter.Counter('transfers').add(1)
 })

--- a/skills/sentio-processor/references/sui-sdk4-migration.md
+++ b/skills/sentio-processor/references/sui-sdk4-migration.md
@@ -2,6 +2,17 @@
 
 Use this when **upgrading a Sui processor to Sentio SDK 4**, or writing one that touches **raw** transaction / object / event structures (reading fields off `ctx.transaction`, walking programmable-transaction commands, decoding an object from `ctx.client.getObject`, or parsing Move type strings).
 
+## SDK 4 is a multi-chain major — not just Sui
+
+Most of this doc covers the Sui gRPC raw-data shapes, which are the largest source of processor code changes. But SDK 4 is a breaking major across the board, so an upgrade also involves:
+
+- **Bump deps to `^4.0.0`.** Set both `@sentio/sdk` and `@sentio/cli` to `^4.0.0` (the `latest` npm tag is now `4.x`), then `sentio gen` to regenerate bindings.
+- **Solana migrated to `@anchor-lang/core` + `@solana/kit`.** If your processor decodes instructions with an Anchor coder, import `BorshInstructionCoder` / `Idl` / `Instruction` from `@sentio/sdk/solana` instead of `@coral-xyz/anchor` (`import { BorshInstructionCoder, type Idl } from '@sentio/sdk/solana'`).
+- **Proto/RPC stack swapped to protobuf-es + connect-es** (from ts-proto + nice-grpc). This is internal to the runtime, but if you import directly from `@sentio/protos` (e.g. constructing proto messages in tests), the API changed: `create(FooSchema, init)` instead of `Foo.fromPartial`, `toBinary`/`fromBinary`/`fromJson(FooSchema, …)` for (de)serialization, and `oneof` fields are discriminated unions.
+- **The v3 back-compat layer is gone.** The SDK 4 runtime no longer patches old (v3) processor shapes and drops deprecated proto fields, so a v3 processor won't run unmodified on a v4 driver — you must actually migrate, not just rely on the runtime papering over differences.
+
+The rest of this doc is the Sui-specific deep dive.
+
 ## Overview
 
 On **SDK 4**, Sui processors fetch on-chain data over **gRPC**. The decoded values from typed handlers are unchanged — the SDK normalizes them. But any code that reaches into **raw** transaction, event, or object structures now sees the **gRPC protobuf shapes**, which differ from the older JSON-RPC shapes in field names, nesting, `oneof` unions, and string formatting.
@@ -23,6 +34,8 @@ This is a fork of an upstream schema that evolves, so field names/shapes can cha
 - Logic that only uses decoded values (amounts, metrics, store entities).
 
 You only adapt code that reads **raw** structures (`ctx.transaction.*` beyond `data_decoded`, objects from `ctx.client`, type strings).
+
+**Exception — `onObjectChange`:** the `changes` array passed to object-change handlers (`SuiObjectTypeProcessor.bind(...).onObjectChange((changes, ctx) => …)`) is no longer the JSON-RPC object shape — on SDK 4 it is the unified `SuiClientTypes.ChangedObject[]` from `@mysten/sui`. If your handler reads fields off those entries (object type, owner, id), re-check them against the unified type; `onEventXxx` decoded payloads are unaffected.
 
 ## protobuf `oneof` pattern
 


### PR DESCRIPTION
## Why

`@sentio/sdk@latest` and `@sentio/cli@latest` are both now `4.0.0`, but the `sentio-processor` skill still shipped v3 guidance, and the new `sui-sdk4-migration.md` reference was scoped to Sui only — reading as if Sui were the only thing v4 touched. v4 (`release(major): begin v4`) is a breaking major across multiple chains.

## Changes

**`SKILL.md`**
- Bump recommended deps from `^3.4.0` → `^4.0.0` (both `@sentio/sdk` and `@sentio/cli`).
- Update the Solana example to the v4 API: import `BorshInstructionCoder` / `Idl` from `@sentio/sdk/solana` (the `@anchor-lang/core` + `@solana/kit` migration) instead of the old `@coral-xyz/anchor` `Anchor.BorshInstructionCoder` form.
- Broaden the progressive-disclosure description of the migration reference.

**`references/sui-sdk4-migration.md`**
- Add a "SDK 4 is a multi-chain major — not just Sui" preamble covering the non-Sui breaks an upgrade hits: dep bumps, the Solana stack change, the protobuf-es/connect-es proto-RPC swap (affects direct `@sentio/protos` users), and the removed v3 back-compat layer.
- Flag that `onObjectChange`'s `changes` array is no longer the JSON-RPC shape but the unified `SuiClientTypes.ChangedObject[]` — a decoded-value exception to the doc's "decoded values are unchanged" claim.

## Verification

Findings were checked against the actual v4 SDK source:
- `@sentio/sdk`/`@sentio/cli` `latest = 4.0.0` (npm dist-tags).
- Solana re-exports `BorshInstructionCoder`/`Instruction`/`Idl` from `@anchor-lang/core` via `@sentio/sdk/solana`.
- The Sui migration doc's existing `ctx.client.getObject({ objectId, include: { json: true } })` → `obj.object.type`/`obj.object.json` claims match the real `@mysten/sui` `SuiGrpcClient` types (left as-is; verified accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)