### PR TITLE
docs(skill): refresh sentio-processor skill for SDK 4

### DIFF
--- a/skills/sentio-processor/SKILL.md
+++ b/skills/sentio-processor/SKILL.md
@@ -85,8 +85,6 @@ After upload, use `sentio processor status --project <owner>/<slug>` to check th
 
 ## package.json
 
-Recommend **yarn** over npm. With npm you may hit `BaseContract` / `DeferredTopicFilter` type conflicts (TS2344 due to duplicate ethers).
-
 ```json
 {
   "name": "project-name",
@@ -102,13 +100,16 @@ Recommend **yarn** over npm. With npm you may hit `BaseContract` / `DeferredTopi
   },
   "devDependencies": {
     "@sentio/cli": "^4.0.0",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   }
 }
 ```
 
-If using npm and hitting ethers type conflicts, add:
+**ethers:** SDK 4 uses **upstream `ethers` 6.x** — the old `@sentio/ethers` fork has been dropped. Do **not** pin or override `ethers` to `@sentio/ethers`. When migrating an older project, **remove** any leftover override such as:
+
 ```json
+// ❌ remove this from older projects — it reintroduces the fork and causes
+//    duplicate-ethers type conflicts (BaseContract / DeferredTopicFilter, TS2344)
 "overrides": {
   "ethers": "npm:@sentio/ethers@6.13.1-patch.4"
 }


### PR DESCRIPTION
Updates the `sentio-processor` Claude Code skill for the Sentio SDK 4 dependency changes.

## Changes
- **Drop the `@sentio/ethers` fork guidance.** SDK 4 uses upstream `ethers` 6.x and the Sentio fork has been removed. Removed the `overrides` recommendation pinning `@sentio/ethers` (and the yarn-over-npm workaround that only existed because of it), and now instruct migrating projects to **delete** any leftover fork override — re-adding it reintroduces duplicate-ethers `BaseContract`/`DeferredTopicFilter` type conflicts (TS2344).
- **Bump `typescript` pin to `^6.0.3`** in the package.json example, matching the SDK 4 CLI templates.

## Why
SDK 4 dropped the `@sentio/ethers` fork in favor of upstream ethers and moved to TypeScript 6, so the skill's generated package.json guidance needs to match or it produces processors with stale, conflicting dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)